### PR TITLE
CI and playbook cleanups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,15 @@ on:
       - 'vm-resources/**'
   workflow_dispatch:
 
+# A full build takes ~20 minutes, so never let pushes pile up on one branch.
+concurrency:
+  group: ci-docker-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     # Matches the Debian 13 guest defined in container-lab.yaml. ubuntu:24.10
     # (oracular) went end-of-life in July 2025 and its archive is gone.
     container: 'debian:13'
@@ -20,22 +26,25 @@ jobs:
       - name: Install dependencies
         run: apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -yqq ansible git python3-apt build-essential sudo
       - run: id
+
       - name: Run demo playbook
         run: ansible-playbook -v --inventory "localhost," --connection=local playbook.yaml
-      - run: bwrap --version
-      - run: conmon --version
-      - run: containerd --version
-      - run: crio --version
-      - run: crun --version
-      - run: ctop -v
-      - run: ignite version
-      - run: podman --version
-      - run: rootlesskit --version
-      - run: runc --version
-      # - run: runsc --version
-      - run: skopeo --version
-      # podman 5 networking. netavark and aardvark-dns install into
-      # libexec/podman, which is deliberately not on PATH.
-      - run: /usr/local/libexec/podman/netavark --version
-      - run: /usr/local/libexec/podman/aardvark-dns --version
-      - run: pasta --version
+
+      # The list of tools lives in versions.sh so it is not duplicated here.
+      - name: Check version of built tools
+        run: bash vm-resources/test-scripts/versions.sh
+
+      - name: Collect diagnostics
+        if: failure()
+        run: |
+          set +e
+          echo "::group::installed lab binaries"
+          ls -la /usr/local/bin /usr/local/sbin
+          ls -la /usr/local/libexec/podman /usr/local/libexec/cni
+          echo "::endgroup::"
+          echo "::group::toolchains"
+          go version; rustc --version; cargo --version; protoc --version
+          echo "::endgroup::"
+          echo "::group::disk"
+          df -h
+          echo "::endgroup::"

--- a/playbook.yaml
+++ b/playbook.yaml
@@ -29,8 +29,7 @@
     - name: Install build dependencies for runc
       apt:
         state: present
-        name: "{{ item }}"
-      loop:
+        name:
         - golang
         - libseccomp2
         - libseccomp-dev
@@ -40,8 +39,7 @@
     - name: Install build dependencies for crun
       apt:
         state: present
-        name: "{{ item }}"
-      loop:
+        name:
         - make
         - git
         - gcc
@@ -69,8 +67,7 @@
     - name: Install build dependencies for skopeo
       apt:
         state: present
-        name: "{{ item }}"
-      loop:
+        name:
         - libdevmapper-dev
         - libgpgme-dev
         - go-md2man
@@ -80,8 +77,7 @@
     - name: Install build dependencies for youki
       apt:
         state: present
-        name: "{{ item }}"
-      loop:
+        name:
         - pkg-config
         - libsystemd-dev
         - libdbus-glib-1-dev
@@ -94,8 +90,7 @@
     - name: Install build dependencies for containerd
       apt:
         state: present
-        name: "{{ item }}"
-      loop:
+        name:
         - libbtrfs-dev
         - btrfs-progs
       become: true
@@ -104,8 +99,7 @@
     - name: Install build dependencies for conmon
       apt:
         state: present
-        name: "{{ item }}"
-      loop:
+        name:
         - gcc
         - git
         - libc6-dev
@@ -119,8 +113,7 @@
     - name: Install runtime dependencies for rootlesskit
       apt:
         state: present
-        name: "{{ item }}"
-      loop:
+        name:
         - uidmap
       become: true
       when: ansible_os_family == 'Debian'
@@ -146,7 +139,7 @@
         params:
           BINDIR: /usr/local/bin
 
-    - name: configue crun
+    - name: Configure crun
       ansible.builtin.shell: ./autogen.sh && ./configure
       args:
         chdir: "{{ home }}/code/fwilhe-containers/crun"
@@ -164,8 +157,7 @@
     - name: Install build dependencies for bubblewrap
       apt:
         state: present
-        name: "{{ item }}"
-      loop:
+        name:
         - meson
       become: true
       when: ansible_os_family == 'Debian'
@@ -219,7 +211,9 @@
       file:
         path: /usr/local/libexec/cni
         state: directory
-        mode: "777"
+        # Not 777: root runs these plugins for pod networking, so a
+        # world-writable directory would let any user swap them out.
+        mode: "755"
 
     - name: Install CNI plugins
       become: true
@@ -305,8 +299,7 @@
     - name: Install build dependencies for slirp4netns
       apt:
         state: present
-        name: "{{ item }}"
-      loop:
+        name:
         - libglib2.0-dev
         - libslirp-dev
         - libcap-dev
@@ -314,7 +307,7 @@
       become: true
       when: ansible_os_family == 'Debian'
 
-    - name: configue slirp4netns
+    - name: Configure slirp4netns
       ansible.builtin.shell: ./autogen.sh && ./configure --prefix=/usr
       args:
         chdir: "{{ home }}/code/fwilhe-containers/slirp4netns"
@@ -334,7 +327,8 @@
         chdir: "{{ home }}/code/fwilhe-containers/ctop"
         target: build
 
-    - name: Build ctop
+    # ctop's Makefile has no install target.
+    - name: Install ctop
       become: true
       ansible.builtin.shell:
         cmd: cp ctop /usr/local/bin
@@ -355,9 +349,8 @@
     - name: Install a Rust toolchain new enough for netavark
       apt:
         state: present
-        name: "{{ item }}"
         default_release: "{{ ansible_distribution_release }}-backports"
-      loop:
+        name:
         - rustc
         - cargo
       become: true
@@ -366,8 +359,7 @@
     - name: Install build dependencies for netavark and aardvark-dns
       apt:
         state: present
-        name: "{{ item }}"
-      loop:
+        name:
         # netavark's dhcp-proxy generates its client code from protobuf at
         # build time, via prost-build, which shells out to protoc.
         - protobuf-compiler
@@ -415,8 +407,7 @@
     - name: Install runtime dependencies for podman
       apt:
         state: present
-        name: "{{ item }}"
-      loop:
+        name:
         - dbus-user-session
       become: true
       when: ansible_os_family == 'Debian'

--- a/vm-resources/test-scripts/test_tools_installed.py
+++ b/vm-resources/test-scripts/test_tools_installed.py
@@ -1,35 +1,37 @@
 import pytest
 import subprocess
-import json
 
 def run_command(command):
     print(command)
+    # check=True already fails the test on a non-zero exit status.
     output = subprocess.run(command, capture_output=True, check=True)
     stdout = output.stdout.decode("utf-8").rstrip()
     stderr = output.stderr.decode("utf-8").rstrip()
     return (stdout, stderr)
 
-@pytest.mark.parametrize("command,expected", [
-    ('bwrap --version', 0),
-    ('conmon --version', 0),
-    ('containerd --version', 0),
-    ('crio --version', 0),
-    ('crun --version', 0),
-    ('ctop -v', 0),
-    ('ignite version', 0),
-    ('podman --version', 0),
-    ('podman info', 0),
-    ('rootlesskit --version', 0),
-    ('runc --version', 0),
-    # ('runsc --version', 0),
-    ('skopeo --version', 0),
+@pytest.mark.parametrize("command", [
+    'bwrap --version',
+    'conmon --version',
+    'containerd --version',
+    'crio --version',
+    'crun --version',
+    'ctop -v',
+    'ignite version',
+    'podman --version',
+    'podman info',
+    'rootlesskit --version',
+    'runc --version',
+    # 'runsc --version',
+    'skopeo --version',
     # podman 5 networking. netavark and aardvark-dns install into
     # libexec/podman, which is deliberately not on PATH.
-    ('/usr/local/libexec/podman/netavark --version', 0),
-    ('/usr/local/libexec/podman/aardvark-dns --version', 0),
-    ('pasta --version', 0),
+    '/usr/local/libexec/podman/netavark --version',
+    '/usr/local/libexec/podman/aardvark-dns --version',
+    'pasta --version',
 ])
-def test_crun_container_lifecycle(command, expected):
-    stdout, stderr = run_command(command.split(' '))
+def test_tool_runs_and_reports_itself(command):
+    # Deliberately not asserting that stderr is empty: plenty of these write
+    # informational lines there, and doing so made `podman info` fail purely
+    # because it warned about the cgroup manager.
+    stdout, _ = run_command(command.split(' '))
     assert stdout != ""
-    assert stderr == ""

--- a/vm-resources/test-scripts/versions.sh
+++ b/vm-resources/test-scripts/versions.sh
@@ -1,14 +1,24 @@
+#!/bin/bash
+# Single source of truth for the "is it installed and does it run" checks, used
+# by the Docker CI job. Anything needing a real system (podman info, the crun
+# lifecycle) lives in the pytest suite instead, which only the lima job runs.
+#
+# set -e matters: without it every failure here was silently discarded.
+set -euxo pipefail
+
 bwrap --version
 conmon --version
 containerd --version
 crio --version
 crun --version
+ctop -v
+ignite version
 podman --version
-podman info
 rootlesskit --version
 runc --version
 # runsc --version
 skopeo --version
+# netavark and aardvark-dns install into libexec/podman, deliberately not on PATH.
 /usr/local/libexec/podman/netavark --version
 /usr/local/libexec/podman/aardvark-dns --version
 pasta --version


### PR DESCRIPTION
Follow-ups after getting both workflows green. All independently verifiable, no behaviour change to what gets built.

## Workflows

- **Concurrency on the Docker job**, matching the lima one. A series of pushes was leaving several full 20-minute builds racing each other.
- **Failure diagnostics on the Docker job**, so it has the same evidence collection lima got: which binaries actually landed in `/usr/local`, the toolchain versions, and disk usage. Several of the recent debugging cycles would have been shorter with this.
- **`timeout-minutes`** — the job was inheriting the 360-minute default.
- **The 16 hand-written `--version` steps are now a call to `versions.sh`.** That list existed in three places and had to be edited in all three when netavark, aardvark-dns and pasta were added.

## Tests

- **`versions.sh` had no `set -e`**, so every failure in it was silently discarded — the script could not fail. It is now what the Docker job runs, so this matters. While reconciling, `podman info` moves out of it into pytest (it needs a real system), and the two lists turned out to disagree about `ctop` and `ignite`.
- **Stop asserting `stderr == ""`.** Plenty of these tools write informational output to stderr, and this assertion cost two debugging cycles on `podman info`, which was failing purely because it warned about the cgroup manager. `check=True` already covers the exit status, which made the `expected` parameter dead.
- Rename the test — it was a copy of the crun lifecycle test's name and tests neither crun nor a lifecycle.

## Playbook

- **Pass package lists to `apt` directly instead of looping.** With `loop`, ansible runs a separate apt transaction per package, so 12 tasks were doing roughly 50 dependency resolutions and dpkg runs. The resulting package lists are verified identical to before.
- **`/usr/local/libexec/cni` was created `777`.** root runs those plugins for pod networking, so any user on the box could swap one out. Now `755`.
- Fix the `configue` typos, and rename the second `Build ctop` task to `Install ctop`, which is what it does.

## Deliberately not here

Idempotency checking (run the playbook twice, assert `changed=0`) and Go/cargo build caching are both worth doing but more invasive — separate PR, so a failure points at one thing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)